### PR TITLE
removing the `contains` at top level

### DIFF
--- a/mmif-python/mmif/serialize/contain.py
+++ b/mmif-python/mmif/serialize/contain.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Union
 
 from .model import MmifObject
@@ -5,11 +6,11 @@ from .model import MmifObject
 
 class Contain(MmifObject):
     producer: str
-    gen_time: str
+    gen_time: datetime
 
     def __init__(self, contain_obj: Union[str, dict] = None):
         self.producer = ''
-        self.gen_time = None     # datetime.datetime
+        self.gen_time = datetime.now()     # datetime.datetime
         super().__init__(contain_obj)
 
     def _deserialize(self, contain_dict: dict):

--- a/mmif-python/mmif/serialize/mmif.py
+++ b/mmif-python/mmif/serialize/mmif.py
@@ -15,11 +15,6 @@ class Mmif(MmifObject):
     context: str
     metadata: Dict[str, str]
     media: List[Medium]
-    # this contains is different from contains field in view, in that this is only for sniffing purpose
-    # and has view ids only
-    # TODO (krim @ 7/7/20): should these lists be sorted? default behavior of `get_view_contains` would be
-    # returning the latest view, so the list should sorted by generation timestamp, I guess.
-    contains: Dict[str, List[str]]
     views: List['View']
 
     def __init__(self, mmif_obj: Union[str, dict] = None, validate: bool = True):
@@ -87,5 +82,12 @@ class Mmif(MmifObject):
                 return view
         raise Exception("{} view not found".format(id))
 
+    def get_all_views_contain(self, at_type: str):
+        return [view for view in self.views if at_type in view.contains]
+
     def get_view_contains(self, at_type: str):
-        return self.get_view_by_id(self.contains[at_type][-1])
+        # will return the *latest* view
+        for view in reversed(self.views):
+            if at_type in view.contains:
+                return view
+        return None

--- a/schema/mmif.json
+++ b/schema/mmif.json
@@ -10,12 +10,12 @@
             "format": "uri"
         },
         "metadata": {
-            "$ref": "#/definitions/doc_metadata"
+            "$ref": "#/definitions/mmif_metadata"
         },
         "media": {
             "type": "array",
             "items": {
-                "$ref": "#/definitions/media"
+                "$ref": "#/definitions/medium"
             }
         },
         "views": {
@@ -32,11 +32,7 @@
         "views"
     ],
     "definitions": {
-        "map": {
-            "type": "object",
-            "additionalProperties": true
-        },
-        "doc_metadata": {
+        "mmif_metadata": {
             "type": "object",
             "properties": {
                 "mmif": {
@@ -44,10 +40,9 @@
                     "format": "uri"
                 },
                 "contains": {
-                    "$ref": "#/definitions/map"
-                }
+              "type": "object"
+                  }
             },
-            "additionalProperties": true,
             "required": [
                 "mmif"
             ]
@@ -66,17 +61,16 @@
                     "format": "uri"
                 },
                 "contains": {
-                    "$ref": "#/definitions/map"
+            "type": "object"
                 }
             },
-            "additionalProperties": true,
             "required": [
                 "medium",
                 "tool",
                 "contains"
             ]
         },
-        "media_metadata": {
+        "medium_metadata": {
             "type": "object",
             "properties": {
                 "source": {
@@ -87,13 +81,12 @@
                     "format": "uri"
                 }
             },
-            "additionalProperties": true,
             "required": [
                 "source",
                 "tool"
             ]
         },
-        "media": {
+        "medium": {
             "type": "object",
             "properties": {
                 "id": {
@@ -112,7 +105,7 @@
                     "$ref": "#/definitions/text"
                 },
                 "metadata": {
-                    "$ref": "#/definitions/media_metadata"
+                    "$ref": "#/definitions/medium_metadata"
                 },
                 "submedia": {
                     "type": "array",
@@ -140,7 +133,6 @@
                     "$ref": "#/definitions/text"
                 }
             },
-            "additionalProperties": true,
             "required": [
                 "id",
                 "annotation",
@@ -169,10 +161,13 @@
                     "type": "string"
                 },
                 "metadata": {
-                    "$ref": "#/definitions/map"
+            "type": "object"
                 },
                 "annotations": {
-                    "$ref": "#/definitions/annotations"
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/annotation"
+            }
                 }
             },
             "additionalProperties": false,
@@ -181,12 +176,6 @@
                 "metadata",
                 "annotations"
             ]
-        },
-        "annotations": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/annotation"
-            }
         },
         "annotation": {
             "type": "object",
@@ -221,8 +210,7 @@
             },
             "required": [
                 "id"
-            ],
-            "additionalProperties": true
+            ]
         }
     }
 }

--- a/schema/mmif.json
+++ b/schema/mmif.json
@@ -10,7 +10,7 @@
             "format": "uri"
         },
         "metadata": {
-            "$ref": "#/definitions/mmif_metadata"
+            "$ref": "#/definitions/mmifMetadata"
         },
         "media": {
             "type": "array",
@@ -32,7 +32,7 @@
         "views"
     ],
     "definitions": {
-        "mmif_metadata": {
+        "mmifMetadata": {
             "type": "object",
             "properties": {
                 "mmif": {
@@ -47,14 +47,15 @@
                 "mmif"
             ]
         },
-        "view_metadata": {
+        "viewMetadata": {
             "type": "object",
             "properties": {
                 "medium": {
                     "type": "string"
                 },
                 "timestamp": {
-                    "type": "string"
+                    "type": "string",
+                    "format": "date-time"
                 },
                 "tool": {
                     "type": "string",
@@ -70,7 +71,7 @@
                 "contains"
             ]
         },
-        "medium_metadata": {
+        "mediumMetadata": {
             "type": "object",
             "properties": {
                 "source": {
@@ -105,7 +106,7 @@
                     "$ref": "#/definitions/text"
                 },
                 "metadata": {
-                    "$ref": "#/definitions/medium_metadata"
+                    "$ref": "#/definitions/mediumMetadata"
                 },
                 "submedia": {
                     "type": "array",
@@ -184,7 +185,7 @@
                     "type": "string"
                 },
                 "properties": {
-                    "$ref": "#/definitions/properties"
+                    "$ref": "#/definitions/annotationProperties"
                 }
             },
             "required": [
@@ -193,7 +194,7 @@
             ],
             "additionalProperties": false
         },
-        "properties": {
+        "annotationProperties": {
             "type": "object",
             "properties": {
                 "id": {

--- a/schema/mmif.json
+++ b/schema/mmif.json
@@ -1,217 +1,217 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "title": "Multi-Media Interchange Format",
-    "description": "The JSON-LD objects exchanged by CLAMS services.",
-    "type": "object",
-    "additionalProperties": false,
-    "properties": {
-        "@context": {
-            "type": "string",
-            "format": "uri"
-        },
-        "metadata": {
-            "$ref": "#/definitions/mmifMetadata"
-        },
-        "media": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/medium"
-            }
-        },
-        "views": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/view"
-            }
-        }
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Multi-Media Interchange Format",
+  "description": "The JSON-LD objects exchanged by CLAMS services.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "@context": {
+      "type": "string",
+      "format": "uri"
     },
-    "required": [
-        "@context",
-        "metadata",
-        "media",
-        "views"
-    ],
-    "definitions": {
-        "mmifMetadata": {
-            "type": "object",
-            "properties": {
-                "mmif": {
-                    "type": "string",
-                    "format": "uri"
-                },
-                "contains": {
-              "type": "object"
-                  }
-            },
-            "required": [
-                "mmif"
-            ]
+    "metadata": {
+      "$ref": "#/definitions/mmifMetadata"
+    },
+    "media": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/medium"
+      }
+    },
+    "views": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/view"
+      }
+    }
+  },
+  "required": [
+    "@context",
+    "metadata",
+    "media",
+    "views"
+  ],
+  "definitions": {
+    "mmifMetadata": {
+      "type": "object",
+      "properties": {
+        "mmif": {
+          "type": "string",
+          "format": "uri"
         },
-        "viewMetadata": {
-            "type": "object",
-            "properties": {
-                "medium": {
-                    "type": "string"
-                },
-                "timestamp": {
-                    "type": "string",
-                    "format": "date-time"
-                },
-                "tool": {
-                    "type": "string",
-                    "format": "uri"
-                },
-                "contains": {
-            "type": "object"
-                }
-            },
-            "required": [
-                "medium",
-                "tool",
-                "contains"
-            ]
-        },
-        "mediumMetadata": {
-            "type": "object",
-            "properties": {
-                "source": {
-                    "type": "string"
-                },
-                "tool": {
-                    "type": "string",
-                    "format": "uri"
-                }
-            },
-            "required": [
-                "source",
-                "tool"
-            ]
-        },
+        "contains": {
+          "type": "object"
+        }
+      },
+      "required": [
+        "mmif"
+      ]
+    },
+    "viewMetadata": {
+      "type": "object",
+      "properties": {
         "medium": {
-            "type": "object",
-            "properties": {
-                "id": {
-                    "type": "string"
-                },
-                "type": {
-                    "type": "string"
-                },
-                "mime": {
-                    "type": "string"
-                },
-                "location": {
-                    "type": "string"
-                },
-                "text": {
-                    "$ref": "#/definitions/text"
-                },
-                "metadata": {
-                    "$ref": "#/definitions/mediumMetadata"
-                },
-                "submedia": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/submedia"
-                    }
-                }
-            },
-            "additionalProperties": false,
-            "required": [
-                "id",
-                "type"
-            ]
+          "type": "string"
         },
-        "submedia": {
-            "type": "object",
-            "properties": {
-                "id": {
-                    "type": "string"
-                },
-                "annotation": {
-                    "type": "string"
-                },
-                "text": {
-                    "$ref": "#/definitions/text"
-                }
-            },
-            "required": [
-                "id",
-                "annotation",
-                "text"
-            ]
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "tool": {
+          "type": "string",
+          "format": "uri"
+        },
+        "contains": {
+          "type": "object"
+        }
+      },
+      "required": [
+        "medium",
+        "tool",
+        "contains"
+      ]
+    },
+    "mediumMetadata": {
+      "type": "object",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "tool": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "required": [
+        "source",
+        "tool"
+      ]
+    },
+    "medium": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "mime": {
+          "type": "string"
+        },
+        "location": {
+          "type": "string"
         },
         "text": {
-            "type": "object",
-            "properties": {
-                "@value": {
-                    "type": "string"
-                },
-                "@language": {
-                    "type": "string"
-                }
-            },
-            "additionalProperties": false,
-            "required": [
-                "@value"
-            ]
+          "$ref": "#/definitions/text"
         },
-        "view": {
-            "type": "object",
-            "properties": {
-                "id": {
-                    "type": "string"
-                },
-                "metadata": {
-            "type": "object"
-                },
-                "annotations": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/annotation"
-            }
-                }
-            },
-            "additionalProperties": false,
-            "required": [
-                "id",
-                "metadata",
-                "annotations"
-            ]
+        "metadata": {
+          "$ref": "#/definitions/mediumMetadata"
+        },
+        "submedia": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/submedia"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "type"
+      ]
+    },
+    "submedia": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
         },
         "annotation": {
-            "type": "object",
-            "properties": {
-                "@type": {
-                    "type": "string"
-                },
-                "properties": {
-                    "$ref": "#/definitions/annotationProperties"
-                }
-            },
-            "required": [
-                "@type",
-                "properties"
-            ],
-            "additionalProperties": false
+          "type": "string"
         },
-        "annotationProperties": {
-            "type": "object",
-            "properties": {
-                "id": {
-                    "type": "string"
-                },
-                "start": {
-                    "type": "integer",
-                    "minimum": -1
-                },
-                "end": {
-                    "type": "integer",
-                    "minimum": -1
-                }
-            },
-            "required": [
-                "id"
-            ]
+        "text": {
+          "$ref": "#/definitions/text"
         }
+      },
+      "required": [
+        "id",
+        "annotation",
+        "text"
+      ]
+    },
+    "text": {
+      "type": "object",
+      "properties": {
+        "@value": {
+          "type": "string"
+        },
+        "@language": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "@value"
+      ]
+    },
+    "view": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "metadata": {
+          "type": "object"
+        },
+        "annotations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/annotation"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "metadata",
+        "annotations"
+      ]
+    },
+    "annotation": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        },
+        "properties": {
+          "$ref": "#/definitions/annotationProperties"
+        }
+      },
+      "required": [
+        "@type",
+        "properties"
+      ],
+      "additionalProperties": false
+    },
+    "annotationProperties": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "start": {
+          "type": "integer",
+          "minimum": -1
+        },
+        "end": {
+          "type": "integer",
+          "minimum": -1
+        }
+      },
+      "required": [
+        "id"
+      ]
     }
+  }
 }

--- a/schema/mmif.json
+++ b/schema/mmif.json
@@ -38,9 +38,6 @@
         "mmif": {
           "type": "string",
           "format": "uri"
-        },
-        "contains": {
-          "type": "object"
         }
       },
       "required": [


### PR DESCRIPTION
After all discussion (#10), we decided to drop the top level `contains` that's introduced in early prototyping. 
This PR also includes some other clean-up of schema file (including reformatting indentation using **2 spaces** as a block indicator)