### PR TITLE
New internal implementation of data lists (Mmif.media, Mmif.views, View.annotations)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ hs_err_pid* # virtual machine crash logs, see http://www.java.com/en/download/he
 **/dist
 **/*.egg-info
 **/.pytype
+mmif-python/build
 
 # ruby (jekyll)
 Gemfile.lock
@@ -82,6 +83,10 @@ mmif-python/**/res
 
 # jekyll files 
 docs/**/_site/**
+
+# coverage files 
+mmif-python/*coverage*
+mmif-python/htmlcov
 
 # external java library
 /vocabulary/rdf/clams.vocabulary

--- a/mmif-python/mmif/serialize/annotation.py
+++ b/mmif-python/mmif/serialize/annotation.py
@@ -44,7 +44,6 @@ class Annotation(MmifObject):
 
 
 class AnnotationProperties(MmifObject):
-    id: str
     properties: dict
 
     def __init__(self, mmif_obj: Union[str, dict] = None):
@@ -52,11 +51,11 @@ class AnnotationProperties(MmifObject):
         super().__init__(mmif_obj)
 
     @property
-    def id(self):  # type: ignore
+    def id(self):
         return self.properties['id']
 
     @id.setter
-    def id(self, aid):  # type: ignore
+    def id(self, aid):
         self.properties['id'] = aid
 
     def _deserialize(self, input_dict: dict) -> None:

--- a/mmif-python/mmif/serialize/annotation.py
+++ b/mmif-python/mmif/serialize/annotation.py
@@ -23,11 +23,11 @@ class Annotation(MmifObject):
         self._type = at_type
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self.properties.id
 
     @id.setter
-    def id(self, aid):
+    def id(self, aid: str) -> None:
         self.properties.id = aid
 
     def _deserialize(self, input_dict: dict) -> None:
@@ -39,7 +39,7 @@ class Annotation(MmifObject):
         intermediate.update(properties=self.properties._serialize())
         return intermediate
 
-    def add_property(self, name: str, value: str):
+    def add_property(self, name: str, value: str) -> None:
         name = name.replace('@', '_')
         assert name.isidentifier(), "Annotation property name must be a valid Python identifier"
         setattr(self.properties, name, value)

--- a/mmif-python/mmif/serialize/annotation.py
+++ b/mmif-python/mmif/serialize/annotation.py
@@ -9,6 +9,11 @@ class Annotation(MmifObject):
     properties: 'AnnotationProperties'
     _type: str
 
+    def __init__(self, anno_obj: Union[str, dict] = None):
+        self._type = ''
+        self.properties = AnnotationProperties()
+        super().__init__(anno_obj)
+
     @property
     def at_type(self):
         return self._type
@@ -28,14 +33,16 @@ class Annotation(MmifObject):
     def _deserialize(self, input_dict: dict) -> None:
         self._type = input_dict['_type']
         self.properties = AnnotationProperties(input_dict['properties'])
-
-    def __init__(self, anno_obj: Union[str, dict] = None):
-        self._type = ''
-        self.properties = AnnotationProperties()
-        super().__init__(anno_obj)
+        
+    def _serialize(self) -> dict:
+        intermediate = super()._serialize()
+        intermediate.update(properties=self.properties._serialize())
+        return intermediate
 
     def add_property(self, name: str, value: str):
-        self.properties[name] = value
+        name = name.replace('@', '_')
+        assert name.isidentifier(), "Annotation property name must be a valid Python identifier"
+        setattr(self.properties, name, value)
 
 
 class AnnotationProperties(MmifObject):

--- a/mmif-python/mmif/serialize/annotation.py
+++ b/mmif-python/mmif/serialize/annotation.py
@@ -40,20 +40,27 @@ class Annotation(MmifObject):
         return intermediate
 
     def add_property(self, name: str, value: str) -> None:
-        name = name.replace('@', '_')
-        assert name.isidentifier(), "Annotation property name must be a valid Python identifier"
-        setattr(self.properties, name, value)
+        self.properties[name] = value
 
 
 class AnnotationProperties(MmifObject):
-    id: str
-    start: Optional[int] = -1
-    end: Optional[int] = -1
     properties: dict
+
+    def __init__(self, mmif_obj: Union[str, dict] = None):
+        if mmif_obj is None:
+            mmif_obj = {}
+        super().__init__(mmif_obj)
+
+    @property
+    def id(self):
+        return self.properties['id']
+
+    @id.setter
+    def id(self, aid: str):
+        self.properties['id'] = aid
 
     def _deserialize(self, input_dict: dict) -> None:
         self.properties = input_dict
-        self.id = input_dict['id']
 
     def _serialize(self):
         return MmifObject(self.properties)._serialize()

--- a/mmif-python/mmif/serialize/medium.py
+++ b/mmif-python/mmif/serialize/medium.py
@@ -20,7 +20,7 @@ class Medium(MmifObject):
         self.type = ''
         super().__init__(medium_obj)
 
-    def _deserialize(self, medium_dict: dict):
+    def _deserialize(self, medium_dict: dict) -> None:
         self.id = medium_dict['id']
         self.type = medium_dict['type']
         if 'metadata' in medium_dict:
@@ -32,7 +32,7 @@ class Medium(MmifObject):
         if 'text' in medium_dict:
             self.text = Text(medium_dict['text'])
 
-    def add_metadata(self, name: str, value: str):
+    def add_metadata(self, name: str, value: str) -> None:
         name = name.replace('@', '_')
         assert name.isidentifier(), "Annotation property name must be a valid Python identifier"
         setattr(self.metadata, name, value)

--- a/mmif-python/mmif/serialize/medium.py
+++ b/mmif-python/mmif/serialize/medium.py
@@ -33,9 +33,7 @@ class Medium(MmifObject):
             self.text = Text(medium_dict['text'])
 
     def add_metadata(self, name: str, value: str) -> None:
-        name = name.replace('@', '_')
-        assert name.isidentifier(), "Annotation property name must be a valid Python identifier"
-        setattr(self.metadata, name, value)
+        self.metadata[name] = value
 
 
 class Text(MmifObject):

--- a/mmif-python/mmif/serialize/medium.py
+++ b/mmif-python/mmif/serialize/medium.py
@@ -33,7 +33,9 @@ class Medium(MmifObject):
             self.text = Text(medium_dict['text'])
 
     def add_metadata(self, name: str, value: str):
-        self.metadata[name] = value
+        name = name.replace('@', '_')
+        assert name.isidentifier(), "Annotation property name must be a valid Python identifier"
+        setattr(self.metadata, name, value)
 
 
 class Text(MmifObject):

--- a/mmif-python/mmif/serialize/mmif.py
+++ b/mmif-python/mmif/serialize/mmif.py
@@ -54,11 +54,14 @@ class Mmif(MmifObject):
     def new_view(self) -> View:
         new_view = View()
         new_view.id = self.new_view_id()
-        self.views[new_view.id] = new_view
+        self.views.append(new_view)
         return new_view
 
-    def add_medium(self, medium: Medium):
-        self.media.append(medium)
+    def add_view(self, view: View, overwrite=False):
+        self.views.append(view, overwrite)
+
+    def add_medium(self, medium: Medium, overwrite=False):
+        self.media.append(medium, overwrite)
 
     def get_media_by_source_view_id(self, source_vid: str = None) -> List[Medium]:
         """
@@ -80,7 +83,6 @@ class Mmif(MmifObject):
         Method to retrieve media by an arbitrary key-value pair in the medium metadata objects
         """
         return [medium for medium in self.media if medium.metadata[metadata_key] == metadata_value]
-
 
     def get_media_locations(self, m_type: str) -> List[str]:
         """
@@ -166,8 +168,8 @@ class MediaList(DataList[Medium]):
     def _deserialize(self, input_list: list) -> None:
         self.items = {item['id']: Medium(item) for item in input_list}
 
-    def append(self, value: Medium):
-        super()._append_with_key(value.id, value)
+    def append(self, value: Medium, overwrite=False):
+        super()._append_with_key(value.id, value, overwrite)
 
 
 class ViewsList(DataList[View]):
@@ -175,5 +177,5 @@ class ViewsList(DataList[View]):
     def _deserialize(self, input_list: list) -> None:
         self.items = {item['id']: View(item) for item in input_list}
 
-    def append(self, value: View):
-        super()._append_with_key(value.id, value)
+    def append(self, value: View, overwrite=False):
+        super()._append_with_key(value.id, value, overwrite)

--- a/mmif-python/mmif/serialize/mmif.py
+++ b/mmif-python/mmif/serialize/mmif.py
@@ -129,21 +129,13 @@ class Mmif(MmifObject):
         return anno_result or view_result or medium_result
 
 
-class MediaList(DataList):
-    items: Dict[str, Medium]
+class MediaList(DataList[Medium]):
 
     def _deserialize(self, input_list: list) -> None:
         self.items = {item['id']: Medium(item) for item in input_list}
 
-    def get(self, key: str) -> Optional[Medium]:
-        return super().get(key)
 
-
-class ViewsList(DataList):
-    items: Dict[str, View]
+class ViewsList(DataList[View]):
 
     def _deserialize(self, input_list: list) -> None:
         self.items = {item['id']: View(item) for item in input_list}
-
-    def get(self, key: str) -> Optional[View]:
-        return super().get(key)

--- a/mmif-python/mmif/serialize/mmif.py
+++ b/mmif-python/mmif/serialize/mmif.py
@@ -119,7 +119,7 @@ class Mmif(MmifObject):
         medium_result = self.media.get(split_attempt[0])
         view_result = self.views.get(split_attempt[0])
 
-        if len(split_attempt) == 1 or not view_result:
+        if len(split_attempt) == 1:
             anno_result = None
         elif view_result:
             anno_result = view_result[split_attempt[1]]

--- a/mmif-python/mmif/serialize/mmif.py
+++ b/mmif-python/mmif/serialize/mmif.py
@@ -71,15 +71,15 @@ class Mmif(MmifObject):
         raise Exception("{} type media not found".format(md_type))
 
     def get_medium_by_id(self, req_med_id: str) -> Medium:
-        result = self[req_med_id]
-        if not isinstance(result, Medium):
+        result = self.media.get(req_med_id)
+        if result is None:
             raise KeyError("{} medium not found".format(req_med_id))
         return result
 
     def get_view_by_id(self, req_view_id: str) -> View:
-        result = self[req_view_id]
-        if not isinstance(result, View):
-            raise KeyError("{} medium not found".format(req_view_id))
+        result = self.views.get(req_view_id)
+        if result is None:
+            raise KeyError("{} view not found".format(req_view_id))
         return result
 
     def get_all_views_contain(self, at_type: str):

--- a/mmif-python/mmif/serialize/mmif.py
+++ b/mmif-python/mmif/serialize/mmif.py
@@ -108,6 +108,8 @@ class Mmif(MmifObject):
         >>> type(obj['v1:bb1'])
         <class 'mmif.serialize.annotation.Annotation'>
         >>> obj['asdf']
+        Traceback (most recent call last):
+            ...
         KeyError: 'ID not found: asdf'
 
         :raises KeyError: if the item is not found or if the search results are ambiguous

--- a/mmif-python/mmif/serialize/mmif.py
+++ b/mmif-python/mmif/serialize/mmif.py
@@ -7,7 +7,7 @@ from pkg_resources import resource_stream
 import mmif
 from .view import View
 from .medium import Medium
-from .model import MmifObject
+from .model import MmifObject, DataList
 
 
 __all__ = ['Mmif']
@@ -23,15 +23,11 @@ class Mmif(MmifObject):
     def __init__(self, mmif_obj: Union[str, dict] = None, validate: bool = True):
         self._context = ''
         self.metadata = {}
-        self.media: 'MediaList' = MediaList([])
-        self.views: 'ViewsList' = ViewsList([])
+        self.media = MediaList()
+        self.views = ViewsList()
         if validate:
             self.validate(mmif_obj)
         super().__init__(mmif_obj)
-
-    # def _serialize(self) -> dict:
-    #     intermediate = super()._serialize()
-    #     return intermediate
 
     def _deserialize(self, input_dict: dict) -> None:
         self._context = input_dict['_context']
@@ -130,40 +126,6 @@ class Mmif(MmifObject):
         if not (view_result or medium_result):
             raise KeyError("ID not found: %s" % item)
         return anno_result or view_result or medium_result
-
-
-class DataList(MmifObject):
-    def __init__(self, mmif_obj: Union[str, list] = None):
-        self.items = dict()
-        if mmif_obj is None:
-            mmif_obj = []
-        super().__init__(mmif_obj)
-
-    def _serialize(self) -> list:
-        return list(self.items.values())
-
-    def deserialize(self, mmif_json: Union[str, list]) -> None:
-        if isinstance(mmif_json, str):
-            mmif_json = json.loads(mmif_json)
-        self._deserialize(mmif_json)
-
-    def get(self, item, default=None):
-        return self.items.get(item, default)
-
-    def __getitem__(self, item):
-        return self.items.__getitem__(item)
-
-    def __setitem__(self, key, value):
-        self.items.__setitem__(key, value)
-
-    def __iter__(self):
-        return self.items.values().__iter__()
-
-    def __len__(self):
-        return self.items.__len__()
-
-    def __reversed__(self):
-        return reversed(self.items.values())
 
 
 class MediaList(DataList):

--- a/mmif-python/mmif/serialize/mmif.py
+++ b/mmif-python/mmif/serialize/mmif.py
@@ -82,6 +82,9 @@ class Mmif(MmifObject):
             raise KeyError("{} medium not found".format(req_view_id))
         return result
 
+    def get_all_views_contain(self, at_type: str):
+        return [view for view in self.views if at_type in view.metadata.contains]
+
     def get_view_contains(self, at_type: str) -> Optional[View]:
         # will return the *latest* view
         # works as of python 3.6+ because dicts are deterministically ordered by insertion order
@@ -89,7 +92,8 @@ class Mmif(MmifObject):
         if version_info < (3, 6):
             print("Warning: get_view_contains requires Python 3.6+ for correct behavior")
         for view in reversed(self.views):
-            return view
+            if at_type in view.metadata.contains:
+                return view
         return None
 
     def __getitem__(self, item: str) -> Union[Medium, View, Annotation]:

--- a/mmif-python/mmif/serialize/mmif.py
+++ b/mmif-python/mmif/serialize/mmif.py
@@ -166,8 +166,14 @@ class MediaList(DataList[Medium]):
     def _deserialize(self, input_list: list) -> None:
         self.items = {item['id']: Medium(item) for item in input_list}
 
+    def append(self, value: Medium):
+        super()._append_with_key(value.id, value)
+
 
 class ViewsList(DataList[View]):
 
     def _deserialize(self, input_list: list) -> None:
         self.items = {item['id']: View(item) for item in input_list}
+
+    def append(self, value: View):
+        super()._append_with_key(value.id, value)

--- a/mmif-python/mmif/serialize/mmif.py
+++ b/mmif-python/mmif/serialize/mmif.py
@@ -135,9 +135,15 @@ class MediaList(DataList):
     def _deserialize(self, input_list: list) -> None:
         self.items = {item['id']: Medium(item) for item in input_list}
 
+    def get(self, key: str) -> Optional[Medium]:
+        return super().get(key)
+
 
 class ViewsList(DataList):
     items: Dict[str, View]
 
     def _deserialize(self, input_list: list) -> None:
         self.items = {item['id']: View(item) for item in input_list}
+
+    def get(self, key: str) -> Optional[View]:
+        return super().get(key)

--- a/mmif-python/mmif/serialize/mmif.py
+++ b/mmif-python/mmif/serialize/mmif.py
@@ -97,6 +97,23 @@ class Mmif(MmifObject):
         return None
 
     def __getitem__(self, item: str):
+        """
+        getitem implementation for Mmif.
+
+        >>> obj = Mmif('''{"@context": "http://mmif.clams.ai/0.1.0/context/mmif.json","metadata": {"mmif": "http://mmif.clams.ai/0.1.0","contains": {"http://mmif.clams.ai/vocabulary/0.1.0/BoundingBox": ["v1"]}},"media": [{"id": "m1","type": "image","mime": "image/jpeg","location": "/var/archive/image-0012.jpg"}],"views": [{"id": "v1","metadata": {"contains": {"BoundingBox": {"unit": "pixels"}},"medium": "m1","tool": "http://tools.clams.io/east/1.0.4"},"annotations": [{"@type": "BoundingBox","properties": {"id": "bb1","coordinates": [[90,40], [110,40], [90,50], [110,50]] }}]}]}''')
+        >>> type(obj['m1'])
+        <class 'mmif.serialize.medium.Medium'>
+        >>> type(obj['v1'])
+        <class 'mmif.serialize.view.View'>
+        >>> type(obj['v1:bb1'])
+        <class 'mmif.serialize.annotation.Annotation'>
+        >>> obj['asdf']
+        KeyError: 'ID not found: asdf'
+
+        :raises KeyError: if the item is not found or if the search results are ambiguous
+        :param item: the search string, a medium ID, a view ID, or a view-scoped annotation ID
+        :return: the object searched for
+        """
         split_attempt = item.split(':')
 
         medium_result = self.media.get(split_attempt[0])

--- a/mmif-python/mmif/serialize/mmif.py
+++ b/mmif-python/mmif/serialize/mmif.py
@@ -49,7 +49,12 @@ class Mmif(MmifObject):
         jsonschema.validate(json_str, schema)
 
     def new_view_id(self) -> str:
-        return 'v_' + str(len(self.views))
+        index = str(len(self.views))
+        new_id = 'v_' + index
+        while new_id in self.views:
+            index += 1
+            new_id = 'v_' + index
+        return new_id
 
     def new_view(self) -> View:
         new_view = View()

--- a/mmif-python/mmif/serialize/model.py
+++ b/mmif-python/mmif/serialize/model.py
@@ -159,6 +159,12 @@ class DataList(MmifObject, Generic[T]):
         except KeyError:
             return None
 
+    def _append_with_key(self, key: str, value: T) -> None:
+        if key in self.items:
+            raise KeyError(f"Key {key} already exists")
+        else:
+            self[key] = value
+
     def __getitem__(self, key: str):
         return self.items.__getitem__(key)
 

--- a/mmif-python/mmif/serialize/model.py
+++ b/mmif-python/mmif/serialize/model.py
@@ -1,6 +1,5 @@
 import json
-from typing import Union, Any, Dict
-
+from typing import Union, Any, Dict, Optional
 
 __all__ = ['MmifObject', 'MmifObjectEncoder', 'DataList']
 
@@ -42,7 +41,7 @@ class MmifObject(object):
         return d
 
     @staticmethod
-    def _load_json(json_obj: Union[dict, str]):
+    def _load_json(json_obj: Union[dict, str]) -> dict:
         """
         Maps JSON-LD-format MMIF strings and dicts into Python dicts
         with identifier-compliant keys. To do this, it replaces "@"
@@ -56,13 +55,13 @@ class MmifObject(object):
         :param json_str:
         :return:
         """
-        def to_atsign(d: Dict[str, Any]):
+        def to_atsign(d: Dict[str, Any]) -> dict:
             for k in list(d.keys()):
                 if k.startswith('@'):
                     d[f'_{k[1:]}'] = d.pop(k)
             return d
 
-        def traverse_to_atsign(d: dict):
+        def traverse_to_atsign(d: dict) -> dict:
             new_d = d.copy()
             to_atsign(new_d)
             for key, value in new_d.items():
@@ -133,7 +132,7 @@ class MmifObjectEncoder(json.JSONEncoder):
 
 class DataList(MmifObject):
     def __init__(self, mmif_obj: Union[str, list] = None):
-        self.items = dict()
+        self.items: Dict[str, MmifObject] = dict()
         if mmif_obj is None:
             mmif_obj = []
         super().__init__(mmif_obj)
@@ -146,8 +145,8 @@ class DataList(MmifObject):
             mmif_json = json.loads(mmif_json)
         self._deserialize(mmif_json)
 
-    def get(self, item, default=None):
-        return self.items.get(item, default)
+    def get(self, key: str) -> Optional[MmifObject]:
+        return self.items.get(key)
 
     def __getitem__(self, item):
         return self.items.__getitem__(item)

--- a/mmif-python/mmif/serialize/model.py
+++ b/mmif-python/mmif/serialize/model.py
@@ -1,5 +1,5 @@
 import json
-from typing import Union, Any, Dict, Optional
+from typing import Union, Any, Dict, Optional, Type
 
 __all__ = ['MmifObject', 'MmifObjectEncoder', 'DataList']
 
@@ -132,7 +132,7 @@ class MmifObjectEncoder(json.JSONEncoder):
 
 class DataList(MmifObject):
     def __init__(self, mmif_obj: Union[str, list] = None):
-        self.items: Dict[str, MmifObject] = dict()
+        self.items: Dict[str, Type[MmifObject]] = dict()
         if mmif_obj is None:
             mmif_obj = []
         super().__init__(mmif_obj)
@@ -145,13 +145,16 @@ class DataList(MmifObject):
             mmif_json = json.loads(mmif_json)
         self._deserialize(mmif_json)
 
-    def get(self, key: str) -> Optional[MmifObject]:
+    def _deserialize(self, input_dict):
+        raise NotImplementedError
+
+    def get(self, key: str) -> Optional[Type[MmifObject]]:
         return self.items.get(key)
 
-    def __getitem__(self, item):
-        return self.items.__getitem__(item)
+    def __getitem__(self, key: str):
+        return self.items.__getitem__(key)
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key: str, value: Type[MmifObject]):
         self.items.__setitem__(key, value)
 
     def __iter__(self):

--- a/mmif-python/mmif/serialize/model.py
+++ b/mmif-python/mmif/serialize/model.py
@@ -147,11 +147,11 @@ class DataList(MmifObject, Generic[T]):
             mmif_json = json.loads(mmif_json)
         self._deserialize(mmif_json)
 
-    def _deserialize(self, input_dict):
-        raise NotImplementedError
-
     def get(self, key: str) -> Optional[T]:
-        return self.items.get(key)
+        try:
+            return self[key]
+        except KeyError:
+            return None
 
     def __getitem__(self, key: str):
         return self.items.__getitem__(key)

--- a/mmif-python/mmif/serialize/model.py
+++ b/mmif-python/mmif/serialize/model.py
@@ -179,3 +179,6 @@ class DataList(MmifObject, Generic[T]):
 
     def __reversed__(self):
         return reversed(list(self.items.values()))
+
+    def __contains__(self, item):
+        return item in self.items

--- a/mmif-python/mmif/serialize/model.py
+++ b/mmif-python/mmif/serialize/model.py
@@ -2,7 +2,7 @@ import json
 from typing import Union, Any, Dict
 
 
-__all__ = ['MmifObject', 'MmifObjectEncoder']
+__all__ = ['MmifObject', 'MmifObjectEncoder', 'DataList']
 
 
 class MmifObject(object):
@@ -130,3 +130,36 @@ class MmifObjectEncoder(json.JSONEncoder):
         else:
             return json.JSONEncoder.default(self, obj)
 
+
+class DataList(MmifObject):
+    def __init__(self, mmif_obj: Union[str, list] = None):
+        self.items = dict()
+        if mmif_obj is None:
+            mmif_obj = []
+        super().__init__(mmif_obj)
+
+    def _serialize(self) -> list:
+        return list(self.items.values())
+
+    def deserialize(self, mmif_json: Union[str, list]) -> None:
+        if isinstance(mmif_json, str):
+            mmif_json = json.loads(mmif_json)
+        self._deserialize(mmif_json)
+
+    def get(self, item, default=None):
+        return self.items.get(item, default)
+
+    def __getitem__(self, item):
+        return self.items.__getitem__(item)
+
+    def __setitem__(self, key, value):
+        self.items.__setitem__(key, value)
+
+    def __iter__(self):
+        return self.items.values().__iter__()
+
+    def __len__(self):
+        return self.items.__len__()
+
+    def __reversed__(self):
+        return reversed(self.items.values())

--- a/mmif-python/mmif/serialize/model.py
+++ b/mmif-python/mmif/serialize/model.py
@@ -159,8 +159,8 @@ class DataList(MmifObject, Generic[T]):
         except KeyError:
             return None
 
-    def _append_with_key(self, key: str, value: T) -> None:
-        if key in self.items:
+    def _append_with_key(self, key: str, value: T, overwrite=False) -> None:
+        if not overwrite and key in self.items:
             raise KeyError(f"Key {key} already exists")
         else:
             self[key] = value

--- a/mmif-python/mmif/serialize/model.py
+++ b/mmif-python/mmif/serialize/model.py
@@ -164,4 +164,4 @@ class DataList(MmifObject):
         return self.items.__len__()
 
     def __reversed__(self):
-        return reversed(self.items.values())
+        return reversed(list(self.items.values()))

--- a/mmif-python/mmif/serialize/model.py
+++ b/mmif-python/mmif/serialize/model.py
@@ -1,6 +1,8 @@
 import json
-from typing import Union, Any, Dict, Optional, Type
+from typing import Union, Any, Dict, Optional, TypeVar, Generic
 
+
+T = TypeVar('T')
 __all__ = ['MmifObject', 'MmifObjectEncoder', 'DataList']
 
 
@@ -130,9 +132,9 @@ class MmifObjectEncoder(json.JSONEncoder):
             return json.JSONEncoder.default(self, obj)
 
 
-class DataList(MmifObject):
+class DataList(MmifObject, Generic[T]):
     def __init__(self, mmif_obj: Union[str, list] = None):
-        self.items: Dict[str, Type[MmifObject]] = dict()
+        self.items: Dict[str, T] = dict()
         if mmif_obj is None:
             mmif_obj = []
         super().__init__(mmif_obj)
@@ -148,13 +150,13 @@ class DataList(MmifObject):
     def _deserialize(self, input_dict):
         raise NotImplementedError
 
-    def get(self, key: str) -> Optional[Type[MmifObject]]:
+    def get(self, key: str) -> Optional[T]:
         return self.items.get(key)
 
     def __getitem__(self, key: str):
         return self.items.__getitem__(key)
 
-    def __setitem__(self, key: str, value: Type[MmifObject]):
+    def __setitem__(self, key: str, value: T):
         self.items.__setitem__(key, value)
 
     def __iter__(self):

--- a/mmif-python/mmif/serialize/view.py
+++ b/mmif-python/mmif/serialize/view.py
@@ -45,6 +45,19 @@ class View(MmifObject):
         return annotation
 
     def __getitem__(self, item):
+        """
+        getitem implementation for Mmif.
+
+        >>> obj = View('''{"id": "v1","metadata": {"contains": {"BoundingBox": {"unit": "pixels"}},"medium": "m1","tool": "http://tools.clams.io/east/1.0.4"},"annotations": [{"@type": "BoundingBox","properties": {"id": "bb1","coordinates": [[90,40], [110,40], [90,50], [110,50]] }}]}''')
+        >>> type(obj['bb1'])
+        <class 'mmif.serialize.annotation.Annotation'>
+        >>> obj['asdf']
+        KeyError: 'Annotation ID not found: asdf'
+
+        :raises KeyError: if the item is not found or if the search results are ambiguous
+        :param item: the search string.
+        :return: the object searched for
+        """
         anno_result = self.annotations.get(item)
         if not anno_result:
             raise KeyError("Annotation ID not found: %s" % item)

--- a/mmif-python/mmif/serialize/view.py
+++ b/mmif-python/mmif/serialize/view.py
@@ -27,14 +27,14 @@ class View(MmifObject):
     def new_contain(self, at_type: str, contain_dict: dict = None) -> Optional['Contain']:
         return self.metadata.new_contain(at_type, contain_dict)
 
-    def new_annotation(self, aid: str, at_type: str) -> 'Annotation':
+    def new_annotation(self, aid: str, at_type: str, overwrite=False) -> 'Annotation':
         new_annotation = Annotation()
         new_annotation.at_type = at_type
         new_annotation.id = aid
-        return self.add_annotation(new_annotation)
+        return self.add_annotation(new_annotation, overwrite)
 
-    def add_annotation(self, annotation: 'Annotation') -> 'Annotation':
-        self.annotations[annotation.id] = annotation
+    def add_annotation(self, annotation: 'Annotation', overwrite=False) -> 'Annotation':
+        self.annotations.append(annotation, overwrite)
         self.new_contain(annotation.at_type)
         return annotation
 

--- a/mmif-python/mmif/serialize/view.py
+++ b/mmif-python/mmif/serialize/view.py
@@ -46,6 +46,8 @@ class View(MmifObject):
         >>> type(obj['bb1'])
         <class 'mmif.serialize.annotation.Annotation'>
         >>> obj['asdf']
+        Traceback (most recent call last):
+            ...
         KeyError: 'Annotation ID not found: asdf'
 
         :raises KeyError: if the key is not found or if the search results are ambiguous

--- a/mmif-python/mmif/serialize/view.py
+++ b/mmif-python/mmif/serialize/view.py
@@ -103,3 +103,5 @@ class AnnotationsList(DataList[Annotation]):
     def _deserialize(self, input_list: list) -> None:
         self.items = {item['properties']['id']: Annotation(item) for item in input_list}
 
+    def append(self, value: Annotation):
+        super()._append_with_key(value.id, value)

--- a/mmif-python/mmif/serialize/view.py
+++ b/mmif-python/mmif/serialize/view.py
@@ -100,3 +100,6 @@ class AnnotationsList(DataList):
 
     def _deserialize(self, input_list: list) -> None:
         self.items = {item['properties']['id']: Annotation(item) for item in input_list}
+
+    def get(self, key: str) -> Optional[Annotation]:
+        return super().get(key)

--- a/mmif-python/mmif/serialize/view.py
+++ b/mmif-python/mmif/serialize/view.py
@@ -95,11 +95,9 @@ class Contain(MmifObject):
         super().__init__(contain_obj)
 
 
-class AnnotationsList(DataList):
+class AnnotationsList(DataList[Annotation]):
     items: Dict[str, Annotation]
 
     def _deserialize(self, input_list: list) -> None:
         self.items = {item['properties']['id']: Annotation(item) for item in input_list}
 
-    def get(self, key: str) -> Optional[Annotation]:
-        return super().get(key)

--- a/mmif-python/mmif/serialize/view.py
+++ b/mmif-python/mmif/serialize/view.py
@@ -103,5 +103,5 @@ class AnnotationsList(DataList[Annotation]):
     def _deserialize(self, input_list: list) -> None:
         self.items = {item['properties']['id']: Annotation(item) for item in input_list}
 
-    def append(self, value: Annotation):
-        super()._append_with_key(value.id, value)
+    def append(self, value: Annotation, overwrite=False):
+        super()._append_with_key(value.id, value, overwrite)

--- a/mmif-python/mmif/serialize/view.py
+++ b/mmif-python/mmif/serialize/view.py
@@ -19,7 +19,7 @@ class View(MmifObject):
         self.annotations = AnnotationsList()
         super().__init__(view_obj)
 
-    def _deserialize(self, view_dict: dict):
+    def _deserialize(self, view_dict: dict) -> None:
         self.id = view_dict['id']
         self.metadata = ViewMetadata(view_dict['metadata'])
         self.annotations = AnnotationsList(view_dict['annotations'])
@@ -27,7 +27,7 @@ class View(MmifObject):
     def new_contain(self, at_type: str, contain_dict: dict = None) -> Optional['Contain']:
         return self.metadata.new_contain(at_type, contain_dict)
 
-    def new_annotation(self, aid: str, at_type: str):
+    def new_annotation(self, aid: str, at_type: str) -> 'Annotation':
         new_annotation = Annotation()
         new_annotation.at_type = at_type
         new_annotation.id = aid
@@ -38,9 +38,9 @@ class View(MmifObject):
         self.new_contain(annotation.at_type)
         return annotation
 
-    def __getitem__(self, item):
+    def __getitem__(self, key: str) -> 'Annotation':
         """
-        getitem implementation for Mmif.
+        getitem implementation for View.
 
         >>> obj = View('''{"id": "v1","metadata": {"contains": {"BoundingBox": {"unit": "pixels"}},"medium": "m1","tool": "http://tools.clams.io/east/1.0.4"},"annotations": [{"@type": "BoundingBox","properties": {"id": "bb1","coordinates": [[90,40], [110,40], [90,50], [110,50]] }}]}''')
         >>> type(obj['bb1'])
@@ -48,13 +48,13 @@ class View(MmifObject):
         >>> obj['asdf']
         KeyError: 'Annotation ID not found: asdf'
 
-        :raises KeyError: if the item is not found or if the search results are ambiguous
-        :param item: the search string.
+        :raises KeyError: if the key is not found or if the search results are ambiguous
+        :param key: the search string.
         :return: the object searched for
         """
-        anno_result = self.annotations.get(item)
+        anno_result = self.annotations.get(key)
         if not anno_result:
-            raise KeyError("Annotation ID not found: %s" % item)
+            raise KeyError("Annotation ID not found: %s" % key)
         return anno_result
 
 

--- a/mmif-python/tests/test_serialize.py
+++ b/mmif-python/tests/test_serialize.py
@@ -247,6 +247,40 @@ class TestMmif(unittest.TestCase):
         self.assertIsNotNone(view)
         self.assertEqual(view.id, 'v1')
 
+    def test_new_view_id(self):
+        mmif_obj = Mmif(examples['example1'])
+        mmif_obj.new_view()
+        self.assertEqual({'v1', 'v_1'}, set(mmif_obj.views.items.keys()))
+
+    def test_add_medium(self):
+        mmif_obj = Mmif(examples['example1'])
+        med_obj = Medium(ext_video_medium)
+        mmif_obj.add_medium(med_obj)
+        try:
+            mmif_obj.add_medium(med_obj)
+            self.fail("didn't raise exception on duplicate ID add")
+        except KeyError:
+            ...
+        try:
+            mmif_obj.add_medium(med_obj, overwrite=True)
+        except KeyError:
+            self.fail("raised exception on duplicate ID add when overwrite was set to True")
+
+    def test_add_view(self):
+        mmif_obj = Mmif(examples['example3'], validate=False)  # TODO: remove validate=False once 56 is done
+        view_obj = View(view1)
+        view_obj.id = 'v4'
+        mmif_obj.add_view(view_obj)
+        try:
+            mmif_obj.add_view(view_obj)
+            self.fail("didn't raise exception on duplicate ID add")
+        except KeyError:
+            ...
+        try:
+            mmif_obj.add_view(view_obj, overwrite=True)
+        except KeyError:
+            self.fail("raised exception on duplicate ID add when overwrite was set to True")
+
 
 class TestMmifObject(unittest.TestCase):
 

--- a/mmif-python/tests/test_serialize.py
+++ b/mmif-python/tests/test_serialize.py
@@ -354,10 +354,7 @@ class TestView(unittest.TestCase):
         self.maxDiff = None
 
     def test_init(self):
-        try:
-            _ = View(view1)
-        except Exception as ex:
-            self.fail(str(type(ex)) + str(ex.message))
+        _ = View(view1)  # just raise exception
 
     def test_annotation_order_preserved(self):
         view_serial = self.view_obj.serialize()

--- a/mmif-python/tests/test_serialize.py
+++ b/mmif-python/tests/test_serialize.py
@@ -464,6 +464,26 @@ class TestAnnotation(unittest.TestCase):
             new_mmif[f'{view_id}:{anno_id}'].add_property(removed_prop_key, removed_prop_value)
             self.assertEqual(json.loads(new_mmif.serialize()), json.loads(datum['string']))
 
+    def test_id(self):
+        anno_obj: Annotation = self.data['example1']['mmif']['v1:bb1']
+
+        old_id = anno_obj.id
+        self.assertEqual('bb1', old_id)
+
+    def test_change_id(self):
+        anno_obj: Annotation = self.data['example1']['mmif']['v1:bb1']
+
+        anno_obj.id = 'bb2'
+        self.assertEqual('bb2', anno_obj.id)
+
+        serialized = json.loads(anno_obj.serialize())
+        new_id = serialized['properties']['id']
+        self.assertEqual('bb2', new_id)
+
+        serialized_mmif = json.loads(self.data['example1']['mmif'].serialize())
+        new_id_from_mmif = serialized_mmif['views'][0]['annotations'][0]['properties']['id']
+        self.assertEqual('bb2', new_id_from_mmif)
+
 
 class TestMedium(unittest.TestCase):
 

--- a/mmif-python/tests/test_serialize.py
+++ b/mmif-python/tests/test_serialize.py
@@ -377,7 +377,7 @@ class TestAnnotation(unittest.TestCase):
             removed_prop_key, removed_prop_value = list(props.items())[-1]
             props.pop(removed_prop_key)
             new_mmif = Mmif(datum['json'])
-            new_mmif.get_view_by_id(view_id).annotations[0].add_property(removed_prop_key, removed_prop_value)
+            new_mmif[f'{view_id}:{anno_id}'].add_property(removed_prop_key, removed_prop_value)
             self.assertEqual(json.loads(new_mmif.serialize()), json.loads(datum['string']))
 
 

--- a/mmif-python/tests/test_serialize.py
+++ b/mmif-python/tests/test_serialize.py
@@ -20,7 +20,6 @@ from tests.mmif_examples import *
 DEBUG = False
 SKIP_SCHEMA = True, "Skipping TestSchema by default"
 SKIP_FOR_56 = True, "Skipping issue #56 bug"
-NOT_MERGED_40 = True, "Skipping until #40 is merged"
 
 
 class TestMmif(unittest.TestCase):
@@ -224,7 +223,6 @@ class TestMmifObject(unittest.TestCase):
             self.assertEqual(json.loads(examples['example1']), json.loads(fake_out.getvalue()))
 
 
-@unittest.skipIf(*NOT_MERGED_40)
 class TestGetItem(unittest.TestCase):
 
     def setUp(self) -> None:
@@ -287,12 +285,12 @@ class TestGetItem(unittest.TestCase):
 
     def test_view_getitem(self):
         try:
-            bb1 = self.view_obj['bb1']
-            self.assertIs(bb1, self.view_obj.annotations.get('bb1'))
+            s1 = self.view_obj['s1']
+            self.assertIs(s1, self.view_obj.annotations.get('s1'))
         except TypeError:
             self.fail("__getitem__ not implemented")
         except KeyError:
-            self.fail("didn't get annotation 'bb1'")
+            self.fail("didn't get annotation 's1'")
 
 
 class TestView(unittest.TestCase):


### PR DESCRIPTION
I have implemented `__getitem__` for Mmif and View and implemented the Mmif.media, Mmif.views, and View.annotations lists internally as MmifObject::DataList objects that hide the implementation of these lists.

For now, I have implemented DataLists as dicts that serialize into lists. We can continue discussing the pros and cons of using dicts vs lists here or in #40.