### PR TITLE
Fix for #76

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,6 @@ gen
 *.db
 *.sqlite3
 
-
 # java
 *.class
 .mtj.tmp/ # Mobile Tools for Java (J2ME)
@@ -59,17 +58,9 @@ hs_err_pid* # virtual machine crash logs, see http://www.java.com/en/download/he
 **/*.egg-info
 **/.pytype
 
-# ruby (jekyll)
+# ruby and jekyll files 
 Gemfile.lock
-
-# shared folders
-dropbox_shared*/
-github_shared*/
-gdrive_shared*/
-
-# external references
-\!rel_*/
-\!ref_*/
+docs/**/_site/**
 
 # ctag generated file
 tags
@@ -78,11 +69,11 @@ tags
 # auto-generated files
 mmif-python/**/ver
 mmif-python/**/res
+mmif-python/VERSION*
 .hypothesis
 
-# jekyll files 
-docs/**/_site/**
-
+# temporary vocab test files 
+/vocabulary/www/*
 # external java library
 /vocabulary/rdf/clams.vocabulary
 # re-includes

--- a/mmif-python/mmif/serialize/annotation.py
+++ b/mmif-python/mmif/serialize/annotation.py
@@ -40,8 +40,6 @@ class Annotation(MmifObject):
 
 class AnnotationProperties(MmifObject):
     id: str
-    start: Optional[int] = -1
-    end: Optional[int] = -1
     properties: dict
 
     def __init__(self, mmif_obj: Union[str, dict] = None):

--- a/mmif-python/mmif/serialize/annotation.py
+++ b/mmif-python/mmif/serialize/annotation.py
@@ -44,6 +44,18 @@ class AnnotationProperties(MmifObject):
     end: Optional[int] = -1
     properties: dict
 
+    def __init__(self, mmif_obj: Union[str, dict] = None):
+        self.properties = {}
+        super().__init__(mmif_obj)
+
+    @property
+    def id(self):  # type: ignore
+        return self.properties['id']
+
+    @id.setter
+    def id(self, aid):  # type: ignore
+        self.properties['id'] = aid
+
     def _deserialize(self, input_dict: dict) -> None:
         self.properties = input_dict
         self.id = input_dict['id']

--- a/vocabulary/www/.gitignore
+++ b/vocabulary/www/.gitignore
@@ -1,2 +1,0 @@
-!./gitignore
-*


### PR DESCRIPTION
Fixes #76; also removes `start` and `end` attributes from `AnnotationProperties` as they are not required fields and in the current implementation they will be missed by the code anyway. We can reimplement these with their default values later with the ideas discussed in #61.

This is intended as a temporary fix as the implementation here will likely be superseded by what is being discussed in #61 