### PR TITLE
Generalized implementation of #82

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,10 @@ hs_err_pid* # virtual machine crash logs, see http://www.java.com/en/download/he
 **/dist
 **/*.egg-info
 **/.pytype
+mmif-python/build/**
+mmif-python/.coverage
+mmif-python/coverage.xml
+mmif-python/htmlcov
 
 # ruby and jekyll files 
 Gemfile.lock

--- a/mmif-python/Makefile
+++ b/mmif-python/Makefile
@@ -39,7 +39,7 @@ $(artifact):
 # invoking `test` without a VERSION file will generated a dev version - this ensures `make test` runs unmanned
 test: devversion build
 	pytype mmif/
-	python3 -m pytest --doctest-modules
+	python3 -m pytest --doctest-modules --cov=mmif
 
 devversion: VERSION.dev VERSION; cat VERSION
 version: VERSION; cat VERSION

--- a/mmif-python/mmif/serialize/annotation.py
+++ b/mmif-python/mmif/serialize/annotation.py
@@ -1,4 +1,4 @@
-from typing import Union, Optional
+from typing import Union
 
 from .model import MmifObject
 from mmif.vocabulary import AnnotationTypesBase
@@ -13,6 +13,8 @@ class Annotation(MmifObject):
     def __init__(self, anno_obj: Union[str, dict] = None):
         self._type = ''
         self.properties = AnnotationProperties()
+        self.disallow_additional_properties()
+        self._attribute_classes = {'properties': AnnotationProperties}
         super().__init__(anno_obj)
 
     @property
@@ -31,42 +33,13 @@ class Annotation(MmifObject):
     def id(self, aid: str) -> None:
         self.properties.id = aid
 
-    def _deserialize(self, input_dict: dict) -> None:
-        self._type = input_dict['_type']
-        self.properties = AnnotationProperties(input_dict['properties'])
-        
-    def _serialize(self) -> dict:
-        intermediate = super()._serialize()
-        intermediate.update(properties=self.properties._serialize())
-        return intermediate
-
     def add_property(self, name: str, value: str) -> None:
         self.properties[name] = value
 
 
 class AnnotationProperties(MmifObject):
-    properties: dict
+    id: str
 
     def __init__(self, mmif_obj: Union[str, dict] = None):
-        self.properties = {}
+        self.id = ''
         super().__init__(mmif_obj)
-
-    @property
-    def id(self):
-        return self.properties['id']
-
-    @id.setter
-    def id(self, aid):
-        self.properties['id'] = aid
-
-    def _deserialize(self, input_dict: dict) -> None:
-        self.properties = input_dict
-
-    def _serialize(self):
-        return MmifObject(self.properties)._serialize()
-
-    def __setitem__(self, key, value):
-        self.properties[key] = value
-
-    def __getitem__(self, key):
-        return self.properties[key]

--- a/mmif-python/mmif/serialize/annotation.py
+++ b/mmif-python/mmif/serialize/annotation.py
@@ -7,22 +7,22 @@ __all__ = ['Annotation', 'AnnotationProperties']
 
 
 class Annotation(MmifObject):
-    properties: 'AnnotationProperties'
-    _type: Union[str, AnnotationTypesBase]
 
-    def __init__(self, anno_obj: Union[str, dict] = None):
-        self._type = ''
-        self.properties = AnnotationProperties()
+    def __init__(self, anno_obj: Union[str, dict] = None) -> None:
+        self._type: Union[str, AnnotationTypesBase] = ''
+        self.properties: AnnotationProperties = AnnotationProperties()
         self.disallow_additional_properties()
         self._attribute_classes = {'properties': AnnotationProperties}
         super().__init__(anno_obj)
 
     @property
-    def at_type(self):
+    def at_type(self) -> Union[str, AnnotationTypesBase]:
+        # TODO (krim @ 8/19/20): should we always return string? leaving this to return
+        # different types can be confusing for sdk users.
         return self._type
 
     @at_type.setter
-    def at_type(self, at_type: Union[str, AnnotationTypesBase]):
+    def at_type(self, at_type: Union[str, AnnotationTypesBase]) -> None:
         self._type = at_type
 
     @property
@@ -38,8 +38,7 @@ class Annotation(MmifObject):
 
 
 class AnnotationProperties(MmifObject):
-    id: str
 
-    def __init__(self, mmif_obj: Union[str, dict] = None):
-        self.id = ''
+    def __init__(self, mmif_obj: Union[str, dict] = None) -> None:
+        self.id: str = ''
         super().__init__(mmif_obj)

--- a/mmif-python/mmif/serialize/medium.py
+++ b/mmif-python/mmif/serialize/medium.py
@@ -3,7 +3,7 @@ from typing import Union, Optional, List
 from .model import MmifObject
 
 
-__all__ = ['Medium', 'MediumMetadata', 'Submedia']
+__all__ = ['Medium', 'MediumMetadata', 'Submedia', 'Text']
 
 
 class Medium(MmifObject):
@@ -33,8 +33,6 @@ class Medium(MmifObject):
 
     @text_language.setter
     def text_language(self, lang_code: str) -> None:
-        if self.text is None:
-            self.text = Text()
         self.text.lang = lang_code
 
     @property
@@ -43,8 +41,6 @@ class Medium(MmifObject):
 
     @text_value.setter
     def text_value(self, s: str) -> None:
-        if self.text is None:
-            self.text = Text()
         self.text.value = s
 
 

--- a/mmif-python/mmif/serialize/medium.py
+++ b/mmif-python/mmif/serialize/medium.py
@@ -7,22 +7,15 @@ __all__ = ['Medium', 'MediumMetadata', 'Submedia']
 
 
 class Medium(MmifObject):
-    id: str
-    type: str
-    mime: Optional[str] = None
-    location: Optional[str] = None
-    text: Optional['Text'] = None
-    metadata: Optional['MediumMetadata'] = None
-    submedia: Optional[List['Submedia']] = None
 
-    def __init__(self, medium_obj: Union[str, dict] = None):
-        self.id = ''
-        self.type = ''
-        self.mime = ''
-        self.location = ''
-        self.text = Text()
-        self.metadata = MediumMetadata()
-        self.submedia = []
+    def __init__(self, medium_obj: Union[str, dict] = None) -> None:
+        self.id: str = ''
+        self.type: str = ''
+        self.mime: str = ''
+        self.location: str = ''
+        self.text: Text = Text()
+        self.metadata: MediumMetadata = MediumMetadata()
+        self.submedia: List[Submedia] = []
         self.disallow_additional_properties()
         self._attribute_classes = {
             'text': Text,
@@ -35,51 +28,49 @@ class Medium(MmifObject):
         self.metadata[name] = value
 
     @property
-    def text_language(self):
+    def text_language(self) -> str:
         return self.text.lang
 
     @text_language.setter
-    def text_language(self, lang_code: str):
+    def text_language(self, lang_code: str) -> None:
         if self.text is None:
             self.text = Text()
         self.text.lang = lang_code
 
     @property
-    def text_value(self):
+    def text_value(self) -> str:
         return self.text.value
 
     @text_value.setter
-    def text_value(self, s: str):
+    def text_value(self, s: str) -> None:
         if self.text is None:
             self.text = Text()
         self.text.value = s
 
 
 class Text(MmifObject):
-    _value: str
-    _language: Optional[str]
 
-    def __init__(self, text_obj: Union[str, dict] = None):
-        self._value = ''
-        self._language = ''
+    def __init__(self, text_obj: Union[str, dict] = None) -> None:
+        self._value: str = ''
+        self._language: str = ''
         self.disallow_additional_properties()
         super().__init__(text_obj)
 
     @property
-    def lang(self):
+    def lang(self) -> str:
         return self._language
 
     @lang.setter
-    def lang(self, lang_code: str):
+    def lang(self, lang_code: str) -> None:
         # TODO (krim @ 8/11/20): add validation for language code (ISO 639)
         self._language = lang_code
 
     @property
-    def value(self):
+    def value(self) -> str:
         return self._value
 
     @value.setter
-    def value(self, s: str):
+    def value(self, s: str) -> None:
         self._value = s
 
 
@@ -87,7 +78,7 @@ class MediumMetadata(MmifObject):
     source: Optional[str]
     app: Optional[str]
 
-    def __init__(self, mmeta_obj: Union[str, dict] = None):
+    def __init__(self, mmeta_obj: Union[str, dict] = None) -> None:
         # need to set instance variables for ``_named_attributes()`` to work
         self.source = None
         self.app = None
@@ -95,13 +86,11 @@ class MediumMetadata(MmifObject):
 
 
 class Submedia(MmifObject):
-    id: str
-    annotation: str
-    text: 'Text'
 
     def __init__(self, submedium: Union[str, dict] = None):
         # need to set instance variables for ``_named_attributes()`` to work
-        self.id = ""
-        self.annotation = ""
+        self.id: str = ''
+        self.annotation: str = ''
+        self.text: Text = Text()
         self._attribute_classes = {'text': Text}
         super().__init__(submedium)

--- a/mmif-python/mmif/serialize/medium.py
+++ b/mmif-python/mmif/serialize/medium.py
@@ -11,27 +11,25 @@ class Medium(MmifObject):
     type: str
     mime: Optional[str] = None
     location: Optional[str] = None
-    text: Optional['Text'] = None # users don't need to directly access nested text object
+    text: Optional['Text'] = None
     metadata: Optional['MediumMetadata'] = None
     submedia: Optional[List['Submedia']] = None
 
     def __init__(self, medium_obj: Union[str, dict] = None):
         self.id = ''
         self.type = ''
+        self.mime = ''
+        self.location = ''
+        self.text = Text()
         self.metadata = MediumMetadata()
+        self.submedia = []
+        self.disallow_additional_properties()
+        self._attribute_classes = {
+            'text': Text,
+            'metadata': MediumMetadata,
+            'submedia': List[Submedia]
+        }
         super().__init__(medium_obj)
-
-    def _deserialize(self, medium_dict: dict) -> None:
-        self.id = medium_dict['id']
-        self.type = medium_dict['type']
-        if 'metadata' in medium_dict:
-            self.metadata = MediumMetadata(medium_dict.get('metadata'))
-        if 'mime' in medium_dict:
-            self.mime = medium_dict['mime']
-        if 'location' in medium_dict:
-            self.location = medium_dict['location']
-        if 'text' in medium_dict:
-            self.text = Text(medium_dict['text'])
 
     def add_metadata(self, name: str, value: str) -> None:
         self.metadata[name] = value
@@ -41,10 +39,10 @@ class Medium(MmifObject):
         return self.text.lang
 
     @text_language.setter
-    def text_language(self, l: str):
+    def text_language(self, lang_code: str):
         if self.text is None:
             self.text = Text()
-        self.text.lang = l
+        self.text.lang = lang_code
 
     @property
     def text_value(self):
@@ -62,6 +60,9 @@ class Text(MmifObject):
     _language: Optional[str]
 
     def __init__(self, text_obj: Union[str, dict] = None):
+        self._value = ''
+        self._language = ''
+        self.disallow_additional_properties()
         super().__init__(text_obj)
 
     @property
@@ -69,9 +70,9 @@ class Text(MmifObject):
         return self._language
 
     @lang.setter
-    def lang(self, l: str):
+    def lang(self, lang_code: str):
         # TODO (krim @ 8/11/20): add validation for language code (ISO 639)
-        self._language = l
+        self._language = lang_code
 
     @property
     def value(self):
@@ -85,50 +86,22 @@ class Text(MmifObject):
 class MediumMetadata(MmifObject):
     source: Optional[str]
     app: Optional[str]
-    _unnamed_attributes: dict
 
     def __init__(self, mmeta_obj: Union[str, dict] = None):
         # need to set instance variables for ``_named_attributes()`` to work
         self.source = None
         self.app = None
-        self._unnamed_attributes: dict = {}
         super().__init__(mmeta_obj)
-
-    def _named_attributes(self):
-        return (n for n in self.__dict__.keys() if n != '_unnamed_attributes')
-
-    def _deserialize(self, input_dict: dict) -> None:
-        for k, v in input_dict.items():
-            self[k] = v
-
-    def _serialize(self):
-        # TODO (krim @ 8/11/20): this logic can be used for other MMIF classes that have some mandatory, some optional, and a free-for-all map
-        serializing_obj = {}
-        serializing_obj.update(self._unnamed_attributes)
-        for k, v in self.__dict__.items():
-            if k != '_unnamed_attributes' and v is not None:
-                serializing_obj[k] = v
-        # this will override superclasses' __len__ logic because metadata object has two-tiered attributes
-        # we can push this behavior up to the superclass.__len__ method
-        return MmifObject(serializing_obj)._serialize() if len(serializing_obj) > 0 else None
-
-    def __len__(self):
-        return sum([self[named] is not None for named in self._named_attributes()]) + len(self._unnamed_attributes)
-
-    def __setitem__(self, key, value):
-        if key in self._named_attributes():
-            self.__dict__[key] = value
-        else:
-            self._unnamed_attributes[key] = value
-
-    def __getitem__(self, key):
-        if key in self._named_attributes():
-            return self.__dict__[key]
-        else:
-            return self._unnamed_attributes[key]
 
 
 class Submedia(MmifObject):
     id: str
     annotation: str
     text: 'Text'
+
+    def __init__(self, submedium: Union[str, dict] = None):
+        # need to set instance variables for ``_named_attributes()`` to work
+        self.id = ""
+        self.annotation = ""
+        self._attribute_classes = {'text': Text}
+        super().__init__(submedium)

--- a/mmif-python/mmif/serialize/mmif.py
+++ b/mmif-python/mmif/serialize/mmif.py
@@ -1,5 +1,6 @@
 import json
-from typing import Dict, List, Union, Optional
+from datetime import datetime
+from typing import List, Union, Optional
 
 import jsonschema.validators
 from pkg_resources import resource_stream
@@ -17,24 +18,23 @@ __all__ = ['Mmif']
 class Mmif(MmifObject):
     # TODO (krim @ 7/6/20): maybe need IRI/URI as a python class for typing?
     _context: str
-    metadata: Dict[str, str]
+    metadata: 'MmifMetadata'
     media: 'MediaList'
     views: 'ViewsList'
 
     def __init__(self, mmif_obj: Union[str, dict] = None, validate: bool = True):
         self._context = ''
-        self.metadata = {}
+        self.metadata = MmifMetadata()
         self.media = MediaList()
         self.views = ViewsList()
         if validate:
             self.validate(mmif_obj)
+        self.disallow_additional_properties()
+        self._attribute_classes = {
+            'media': MediaList,
+            'views': ViewsList
+        }
         super().__init__(mmif_obj)
-
-    def _deserialize(self, input_dict: dict) -> None:
-        self._context = input_dict['_context']
-        self.metadata = input_dict['metadata']
-        self.media = MediaList(input_dict['media'])
-        self.views = ViewsList(input_dict['views'])
 
     @staticmethod
     def validate(json_str: Union[str, dict]) -> None:
@@ -59,6 +59,7 @@ class Mmif(MmifObject):
     def new_view(self) -> View:
         new_view = View()
         new_view.id = self.new_view_id()
+        new_view.metadata.timestamp = datetime.now()
         self.views.append(new_view)
         return new_view
 
@@ -78,7 +79,8 @@ class Mmif(MmifObject):
         In either case, this method will return all medium objects that generated
         from a view.
         """
-        return [medium for medium in self.media if medium.metadata.source is not None and medium.metadata.source.split(':')[0] == source_vid]
+        return [medium for medium in self.media
+                if medium.metadata.source is not None and medium.metadata.source.split(':')[0] == source_vid]
 
     def get_media_by_app(self, app_id: str) -> List[Medium]:
         return [medium for medium in self.media if medium.metadata.app == app_id]
@@ -93,7 +95,7 @@ class Mmif(MmifObject):
         """
         This method returns the file paths of media of given type.
         """
-        return [medium.location for medium in self.media if medium.type == m_type and medium.location is not None]
+        return [medium.location for medium in self.media if medium.type == m_type and len(medium.location) > 0]
 
     def get_medium_location(self, m_type: str) -> str:
         """
@@ -149,6 +151,8 @@ class Mmif(MmifObject):
         :param item: the search string, a medium ID, a view ID, or a view-scoped annotation ID
         :return: the object searched for
         """
+        if item in self._named_attributes():
+            return self.__dict__[item]
         split_attempt = item.split(':')
 
         medium_result = self.media.get(split_attempt[0])
@@ -166,6 +170,12 @@ class Mmif(MmifObject):
         if not (view_result or medium_result):
             raise KeyError("ID not found: %s" % item)
         return anno_result or view_result or medium_result
+
+
+class MmifMetadata(MmifObject):
+
+    def __init__(self, metadata_obj: Union[str, dict] = None):
+        super().__init__(metadata_obj)
 
 
 class MediaList(DataList[Medium]):

--- a/mmif-python/mmif/serialize/mmif.py
+++ b/mmif-python/mmif/serialize/mmif.py
@@ -1,6 +1,6 @@
 import json
 from datetime import datetime
-from typing import List, Union, Optional
+from typing import List, Union, Optional, Dict
 
 import jsonschema.validators
 from pkg_resources import resource_stream
@@ -16,17 +16,13 @@ __all__ = ['Mmif']
 
 
 class Mmif(MmifObject):
-    # TODO (krim @ 7/6/20): maybe need IRI/URI as a python class for typing?
-    _context: str
-    metadata: 'MmifMetadata'
-    media: 'MediaList'
-    views: 'ViewsList'
 
-    def __init__(self, mmif_obj: Union[str, dict] = None, validate: bool = True):
-        self._context = ''
-        self.metadata = MmifMetadata()
-        self.media = MediaList()
-        self.views = ViewsList()
+    def __init__(self, mmif_obj: Union[str, dict] = None, validate: bool = True) -> None:
+        # TODO (krim @ 7/6/20): maybe need IRI/URI as a python class for typing?
+        self._context: str = ''
+        self.metadata: MmifMetadata = MmifMetadata()
+        self.media: MediaList = MediaList()
+        self.views: ViewsList = ViewsList()
         if validate:
             self.validate(mmif_obj)
         self.disallow_additional_properties()
@@ -63,10 +59,10 @@ class Mmif(MmifObject):
         self.views.append(new_view)
         return new_view
 
-    def add_view(self, view: View, overwrite=False):
+    def add_view(self, view: View, overwrite=False) -> None:
         self.views.append(view, overwrite)
 
-    def add_medium(self, medium: Medium, overwrite=False):
+    def add_medium(self, medium: Medium, overwrite=False) -> None:
         self.media.append(medium, overwrite)
 
     def get_media_by_source_view_id(self, source_vid: str = None) -> List[Medium]:
@@ -85,7 +81,7 @@ class Mmif(MmifObject):
     def get_media_by_app(self, app_id: str) -> List[Medium]:
         return [medium for medium in self.media if medium.metadata.app == app_id]
 
-    def get_media_by_metadata(self, metadata_key: str, metadata_value: str):
+    def get_media_by_metadata(self, metadata_key: str, metadata_value: str) -> List[Medium]:
         """
         Method to retrieve media by an arbitrary key-value pair in the medium metadata objects
         """
@@ -117,7 +113,7 @@ class Mmif(MmifObject):
             raise KeyError("{} view not found".format(req_view_id))
         return result
 
-    def get_all_views_contain(self, at_type: str):
+    def get_all_views_contain(self, at_type: str) -> List[View]:
         return [view for view in self.views if at_type in view.metadata.contains]
 
     def get_view_contains(self, at_type: str) -> Optional[View]:
@@ -174,23 +170,25 @@ class Mmif(MmifObject):
 
 class MmifMetadata(MmifObject):
 
-    def __init__(self, metadata_obj: Union[str, dict] = None):
+    def __init__(self, metadata_obj: Union[str, dict] = None) -> None:
         super().__init__(metadata_obj)
 
 
 class MediaList(DataList[Medium]):
+    items: Dict[str, Medium]
 
     def _deserialize(self, input_list: list) -> None:
         self.items = {item['id']: Medium(item) for item in input_list}
 
-    def append(self, value: Medium, overwrite=False):
+    def append(self, value: Medium, overwrite=False) -> None:
         super()._append_with_key(value.id, value, overwrite)
 
 
 class ViewsList(DataList[View]):
+    items: Dict[str, View]
 
     def _deserialize(self, input_list: list) -> None:
         self.items = {item['id']: View(item) for item in input_list}
 
-    def append(self, value: View, overwrite=False):
+    def append(self, value: View, overwrite=False) -> None:
         super()._append_with_key(value.id, value, overwrite)

--- a/mmif-python/mmif/serialize/mmif.py
+++ b/mmif-python/mmif/serialize/mmif.py
@@ -1,6 +1,6 @@
 import json
 from datetime import datetime
-from typing import List, Union, Optional, Dict
+from typing import List, Union, Optional, Dict, ClassVar
 
 import jsonschema.validators
 from pkg_resources import resource_stream
@@ -16,6 +16,7 @@ __all__ = ['Mmif']
 
 
 class Mmif(MmifObject):
+    view_prefix: ClassVar[str] = 'v_'
 
     def __init__(self, mmif_obj: Union[str, dict] = None, validate: bool = True) -> None:
         # TODO (krim @ 7/6/20): maybe need IRI/URI as a python class for typing?
@@ -45,11 +46,11 @@ class Mmif(MmifObject):
         jsonschema.validate(json_str, schema)
 
     def new_view_id(self) -> str:
-        index = str(len(self.views))
-        new_id = 'v_' + index
+        index = len(self.views)
+        new_id = self.view_prefix + str(index)
         while new_id in self.views:
             index += 1
-            new_id = 'v_' + index
+            new_id = self.view_prefix + str(index)
         return new_id
 
     def new_view(self) -> View:
@@ -118,10 +119,7 @@ class Mmif(MmifObject):
 
     def get_view_contains(self, at_type: str) -> Optional[View]:
         # will return the *latest* view
-        # works as of python 3.6+ because dicts are deterministically ordered by insertion order
-        from sys import version_info
-        if version_info < (3, 6):
-            print("Warning: get_view_contains requires Python 3.6+ for correct behavior")
+        # works as of python 3.6+ (checked by setup.py) because dicts are deterministically ordered by insertion order
         for view in reversed(self.views):
             if at_type in view.metadata.contains:
                 return view

--- a/mmif-python/mmif/serialize/model.py
+++ b/mmif-python/mmif/serialize/model.py
@@ -62,10 +62,6 @@ class MmifObject(object):
     def _named_attributes(self):
         return (n for n in self.__dict__.keys() if n not in self.reversed_names)
 
-    def _named_attribute_class(self, attribute_name: str):
-
-        return self._attribute_classes[attribute_name]
-
     def serialize(self, pretty: bool = False) -> str:
         """
         Generates JSON-LD representation of an object.
@@ -174,12 +170,6 @@ class MmifObject(object):
 
     def __str__(self) -> str:
         return self.serialize(False)
-
-    def pretty(self) -> str:
-        """
-        Call :func: .serialize() with indentation.
-        """
-        return self.serialize(True)
 
     def __eq__(self, other) -> bool:
         return isinstance(other, type(self)) and \

--- a/mmif-python/mmif/serialize/view.py
+++ b/mmif-python/mmif/serialize/view.py
@@ -11,16 +11,12 @@ __all__ = ['View', 'ViewMetadata', 'Contain']
 
 
 class View(MmifObject):
-    _context: str
-    id: str
-    metadata: 'ViewMetadata'
-    annotations: 'AnnotationsList'
 
-    def __init__(self, view_obj: Union[str, dict] = None):
-        self._context = ''
-        self.id = ''
-        self.metadata = ViewMetadata()
-        self.annotations = AnnotationsList()
+    def __init__(self, view_obj: Union[str, dict] = None) -> None:
+        self._context: str = ''
+        self.id: str = ''
+        self.metadata: ViewMetadata = ViewMetadata()
+        self.annotations: AnnotationsList = AnnotationsList()
         self.disallow_additional_properties()
         self._attribute_classes = {
             'metadata': ViewMetadata,
@@ -67,17 +63,12 @@ class View(MmifObject):
 
 
 class ViewMetadata(MmifObject):
-    medium: str
-    timestamp: Optional[datetime] = None
-    app: str
-    contains: Dict[str, 'Contain']
 
-    def __init__(self, viewmetadata_obj: Union[str, dict] = None):
-        # need to set instance variables for ``_named_attributes()`` to work
-        self.medium = ''
-        self.timestamp = None
-        self.app = ''
-        self.contains = {}
+    def __init__(self, viewmetadata_obj: Union[str, dict] = None) -> None:
+        self.medium: str = ''
+        self.timestamp: Optional[datetime] = None
+        self.app: str = ''
+        self.contains: Dict[str, Contain] = {}
         super().__init__(viewmetadata_obj)
 
     def _deserialize(self, input_dict: dict) -> None:
@@ -113,12 +104,11 @@ class ViewMetadata(MmifObject):
 
 
 class Contain(MmifObject):
-    producer: str
-    gen_time: Optional[datetime] = None
 
-    def __init__(self, contain_obj: Union[str, dict] = None):
-        self.producer = ''
-        self.gen_time = None
+    def __init__(self, contain_obj: Union[str, dict] = None) -> None:
+        # TODO (krim @ 8/19/20): rename `producer` to `app` maybe?
+        self.producer: str = ''
+        self.gen_time: Optional[datetime] = None
         super().__init__(contain_obj)
 
     def _deserialize(self, input_dict: dict) -> None:
@@ -133,5 +123,5 @@ class AnnotationsList(DataList[Annotation]):
     def _deserialize(self, input_list: list) -> None:
         self.items = {item['properties']['id']: Annotation(item) for item in input_list}
 
-    def append(self, value: Annotation, overwrite=False):
+    def append(self, value: Annotation, overwrite=False) -> None:
         super()._append_with_key(value.id, value, overwrite)

--- a/mmif-python/tests/test_serialize.py
+++ b/mmif-python/tests/test_serialize.py
@@ -109,14 +109,10 @@ class TestMmif(unittest.TestCase):
         self.assertEqual(old_view_count+1, len(mmif_obj.views))
 
     def test_medium_metadata(self):
-        text = "Karen flew to New York."
-        en = 'en'
         medium = Medium()
         medium.id = 'm999'
         medium.type = "text"
-        medium.text_value = text
-        self.assertEqual(medium.text_value, text)
-        medium.text_language = en
+        medium.location = "random_location"
         medium.metadata['source'] = "v10"
         medium.metadata['app'] = "some_sentence_splitter"
         medium.metadata['random_key'] = "random_value"
@@ -126,9 +122,33 @@ class TestMmif(unittest.TestCase):
         plain_json = json.loads(serialized)
         deserialized = Medium(plain_json)
         self.assertEqual(medium, deserialized)
-        self.assertEqual({'id', 'type', 'text', 'metadata'}, plain_json.keys())
-        self.assertEqual({'@value', '@language'}, plain_json['text'].keys())
+        self.assertEqual({'id', 'type', 'location', 'metadata'}, plain_json.keys())
         self.assertEqual({'source', 'app', 'random_key'}, plain_json['metadata'].keys())
+
+    def test_medium_text(self):
+        text = "Karen flew to New York."
+        en = 'en'
+        medium = Medium()
+        medium.id = 'm998'
+        medium.type = "text"
+        medium.text_value = text
+        self.assertEqual(medium.text_value, text)
+        medium.text_language = en
+        serialized = medium.serialize()
+        plain_json = json.loads(serialized)
+        deserialized = Medium(serialized)
+        self.assertEqual(deserialized.text_value, text)
+        self.assertEqual(deserialized.text_language, en)
+        self.assertEqual({'@value', '@language'}, plain_json['text'].keys())
+
+    def test_medium_empty_text(self):
+        medium = Medium()
+        medium.id = 'm997'
+        medium.type = "text"
+        serialized = medium.serialize()
+        deserialized = Medium(serialized)
+        self.assertEqual(deserialized.text_value, '')
+        self.assertEqual(deserialized.text_language, '')
 
     def test_medium(self):
         medium = Medium(examples['medium_ext_video_example'])
@@ -168,6 +188,11 @@ class TestMmif(unittest.TestCase):
         new_medium.metadata.source = 'v1:bb2'
         mmif_obj.add_medium(new_medium)
         self.assertEqual(len(mmif_obj.get_media_by_source_view_id('v1')), 2)
+
+    def test_get_medium_by_metadata(self):
+        mmif_obj = Mmif(examples['mmif_example1'])
+        self.assertEqual(len(mmif_obj.get_media_by_metadata("source", "v1:bb1")), 1)
+        self.assertEqual(len(mmif_obj.get_media_by_metadata("source", "v3")), 0)
 
     def test_get_medium_by_appid(self):
         tesseract_appid = 'http://apps.clams.io/tesseract/1.2.1'
@@ -210,16 +235,30 @@ class TestMmif(unittest.TestCase):
         self.assertEqual(len(views), views_len)
 
     def test_get_view_contains(self):
-        # TODO (angus-lherrou @ 8/5/2020): expand to better examples once schema is fixed
         mmif_obj = Mmif(examples['mmif_example1'])
         view = mmif_obj.get_view_contains('BoundingBox')
         self.assertIsNotNone(view)
         self.assertEqual('v1', view.id)
+        view = mmif_obj.get_view_contains('NonExistingType')
+        self.assertIsNone(view)
 
     def test_new_view_id(self):
-        mmif_obj = Mmif(examples['mmif_example1'])
-        mmif_obj.new_view()
-        self.assertEqual({'v1', 'v_1'}, set(mmif_obj.views.items.keys()))
+        p = Mmif.view_prefix
+        mmif_obj = Mmif(validate=False)
+        a_view = mmif_obj.new_view()
+        self.assertEqual(a_view.id, f'{p}0')
+        b_view = View()
+        b_view.id = f'{p}2'
+        mmif_obj.add_view(b_view)
+        self.assertEqual({f'{p}0', f'{p}2'}, set(mmif_obj.views.items.keys()))
+        c_view = mmif_obj.new_view()
+        self.assertEqual(c_view.id, f'{p}3')
+        d_view = View()
+        d_view.id = 'v4'
+        mmif_obj.add_view(d_view)
+        e_view = mmif_obj.new_view()
+        self.assertEqual(e_view.id, f'{p}4')
+        self.assertEqual(len(mmif_obj.views), 5)
 
     def test_add_medium(self):
         mmif_obj = Mmif(examples['mmif_example1'])
@@ -250,6 +289,22 @@ class TestMmif(unittest.TestCase):
         except KeyError:
             self.fail("raised exception on duplicate ID add when overwrite was set to True")
 
+    def test___getitem__(self):
+        mmif_obj = Mmif(examples['mmif_example1'])
+        self.assertIsInstance(mmif_obj['m1'], Medium)
+        self.assertIsInstance(mmif_obj['v1'], View)
+        self.assertIsInstance(mmif_obj['v1:bb1'], Annotation)
+        with self.assertRaises(KeyError):
+            mmif_obj['asdf']
+        a_view = View()
+        a_view.id = 'm1'
+        mmif_obj.add_view(a_view)
+        with self.assertRaises(KeyError):
+            mmif_obj['m1']
+        medium = Medium()
+        medium.add_metadata('random_key', 'random_value')
+        self.assertEqual(medium.metadata['random_key'], 'random_value')
+
 
 class TestMmifObject(unittest.TestCase):
 
@@ -271,6 +326,16 @@ class TestMmifObject(unittest.TestCase):
             self.fail()
         except TypeError:
             pass
+
+    def test_under_at_swap(self):
+        text = Text()
+        text.value = "asdf"
+        text.lang = "en"
+        self.assertTrue(hasattr(text, '_value'))
+        self.assertTrue(hasattr(text, '_language'))
+        plain_json = json.loads(text.serialize())
+        self.assertIn('@value', plain_json.keys())
+        self.assertIn('@language', plain_json.keys())
 
     def test_print_mmif(self):
         with patch('sys.stdout', new=StringIO()) as fake_out:


### PR DESCRIPTION
This PR implements generalized two-tiered attributes (#82) and attempts handling of `additionalAttributes` in JSON schema in a pythonic way. I haven't added a lots of test cases, but current implementation passes all existing tests. 