### PR TITLE
Set parent for documents in mmif.serialize.view.View when deserializing existing view

### DIFF
--- a/mmif-python/mmif/serialize/view.py
+++ b/mmif-python/mmif/serialize/view.py
@@ -43,6 +43,9 @@ class View(FreezableMmifObject):
         })
         self._required_attributes = pvector(["id", "metadata", "annotations"])
         super().__init__(view_obj)
+        for item in self.annotations:
+            if isinstance(item, Document):
+                item.parent = self.id
 
     def new_contain(self, at_type: Union[str, ThingTypesBase], contain_dict: dict = None) -> Optional['Contain']:
         """

--- a/mmif-python/tests/test_serialize.py
+++ b/mmif-python/tests/test_serialize.py
@@ -467,6 +467,10 @@ class TestView(unittest.TestCase):
         self.view_obj.new_annotation('relation1', 'Relation')  # raise exception if this fails
         self.assertIn('Relation', self.view_obj.metadata.contains)
 
+    def test_parent(self):
+        mmif_obj = Mmif(self.mmif_examples_json['mmif_example1'])
+        self.assertTrue(all(doc.parent == v.id for v in mmif_obj.views for doc in mmif_obj.get_documents_in_view(v.id)))
+
 
 class TestAnnotation(unittest.TestCase):
     # TODO (angus-lherrou @ 7/27/2020): testing should include validation for required attrs


### PR DESCRIPTION
Fixes #132 
Added test to check for this behavior