### PR TITLE
view metadata uses viewMetadata scheme (#152)

### DIFF
--- a/schema/mmif.json
+++ b/schema/mmif.json
@@ -81,7 +81,7 @@
           "type": "string"
         },
         "metadata": {
-          "type": "object"
+          "type": "#/definitions/viewMetadata"
         },
         "annotations": {
           "type": "array",

--- a/specifications/index.md
+++ b/specifications/index.md
@@ -149,12 +149,12 @@ This property contains information about the annotations in a view. Here is an e
 }
 ```
 
-The *contains* dictionary has keys that refer to annotation objects in the CLAMS or LAPPS vocabulary or properties of those annotation objects (they can also refer to user-defined objects or properties) and they indicate the kind of annotations that live in the view. The value of each of those keys is a JSON object which contains metadata specified for the annotation type. The example above has one key that indicates that the view contains *TimeFrame* annotations and it gives two metadata properties for that annotation type:
+The *contains* dictionary has keys that refer to annotation objects in the CLAMS or LAPPS vocabulary, or user-defined objects. Namely, they indicate the kind of annotations that live in the view. The value of each of those keys is a JSON object which contains properties specified for the annotation type. The example above has one key that indicates that the view contains *TimeFrame* annotations and it gives two metadata properties for that annotation type:
 
 1. The *document* key gives the identifier of the document that the annotations of that type in this view are over. As we will see later, annotations anchor into documents using keys like *start* and *end* and this property specifies what document that is.
 2. The *unit* key is set to "seconds" and this means that for each annotation the unit for the values in *start* and *end* are seconds. 
 
-Note that when a metadata property is set to some value then all annotations of that type should adhere to that value, in this case the document and unit are set to "m1" and "seconds" respectively. It is technically possible to add *documenty* and *unit* properties to individual annotations and overrule the metadata property, but this is not to be done without really good reasons. We get back to this later.
+Note that when a property is set to some value then all annotations of that type should adhere to that value, in this case the document and unit are set to "m1" and "seconds" respectively. In other words, *contains* dictionary not only functions as an overview of the annotation types in this view, but also as a factor-out for common properties shared among annotations of a type. This is useful especially for *document* property, as in a single view, an app is likely to process only one or two source documents and resulting annotation objects will be anchored on those small number of documents. It is technically possible to add *documenty* and *unit* properties to individual annotations and overrule the metadata property, but this is not to be done without really good reasons. We get back to this later.
 
 Section 2 has more details on the interaction between the vocabulary and the metadata for the annotation types in the *contains* dictionary.
 


### PR DESCRIPTION
This PR fixes MMIF json schema to use proper object definition for `viewMetadata`. And other small issues from discussion in #152. 