### PR TITLE
Structures to params and contains

### DIFF
--- a/schema/mmif.json
+++ b/schema/mmif.json
@@ -27,6 +27,14 @@
     "views"
   ],
   "definitions": {
+    "strStrMap": {
+      "type": "object",
+      "patternProperties": {
+        ".+": {
+          "type": "string"
+        }
+      }
+    },
     "mmifMetadata": {
       "type": "object",
       "properties": {
@@ -51,7 +59,16 @@
           "format": "uri"
         },
         "contains": {
-          "type": "object"
+          "type": "object",
+          "additionalProperties": false,
+          "patternProperties": {
+            "^https?:\/\/": {
+              "$ref": "#/definitions/strStrMap"
+            }
+          }
+        },
+        "parameters": {
+          "$ref": "#/definitions/strStrMap"
         }
       },
       "required": [
@@ -128,7 +145,7 @@
           "minimum": -1
         },
         "location": {
-          "type": "string", 
+          "type": "string",
           "format": "uri"
         }
       },
@@ -138,3 +155,4 @@
     }
   }
 }
+


### PR DESCRIPTION
addressing #160. @marcverhagen might have a better specification for `contains` (https://github.com/clamsproject/mmif/issues/152#issuecomment-779905204). 