### PR TITLE
removing data types of non-required annotation properties from JSON schema

### DIFF
--- a/schema/mmif.json
+++ b/schema/mmif.json
@@ -157,18 +157,6 @@
       "properties": {
         "id": {
           "type": "string"
-        },
-        "start": {
-          "type": "integer",
-          "minimum": -1
-        },
-        "end": {
-          "type": "integer",
-          "minimum": -1
-        },
-        "location": {
-          "type": "string",
-          "format": "uri"
         }
       },
       "required": [


### PR DESCRIPTION
Addressing #149. See the issue for discussion. 
