### PR TITLE
releasing 1.0.0

### DIFF
--- a/.github/workflows/issue-infra-project.yml
+++ b/.github/workflows/issue-infra-project.yml
@@ -1,4 +1,4 @@
-name: "add to `apps` GH project when a new issue is submitted"
+name: "add to `infra` GH project when a new issue is submitted"
 
 on:
   issues:

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ MMIF is a data format, developed as a part of CLAMS project, to convey computati
 
 The current version of MMIF is {{ site.navbar-links["VERSIONS"].first.first[0] }} and it is available at [https://mmif.clams.ai/{{ site.navbar-links["VERSIONS"].first.first[0] }}]({{ site.navbar-links["VERSIONS"].first.first[0] }}).
 
-For documentation on the Python distribution package `mmif-python`, visit the [documentation website](https://clams.ai/mmif-python).
+For documentation on the Python distribution package `mmif-python`, visit the [Python API documentation website](https://clams.ai/mmif-python).
 
 Contributions are welcome via [the github issue tracker](https://github.com/clamsproject/mmif/issues).
 


### PR DESCRIPTION
### Overview
MMIF spec has been stable for a long time, and the recent change in handling `@type` version check will make it more stable. So we are releasing 1.0.0 based on 0.5.0. This is simply re-numbering of 0.5.0, hence no technical changes are included in 1.0.0. 
